### PR TITLE
Fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "scrypt.d",
+	"name": "scrypt-d",
 	"description": "A D library for using the scrypt encryption function",
 	"homepage": "http://github.com/BitPuffin/scrypt.d.git",
 	"copyright": "Copyright 2013 Isak Andersson (BitPuffin@lavabit.com)",
@@ -7,9 +7,6 @@
 	"authors": [
 		"Isak Andersson"
 	],
-	"dependencies": {
-	},
-    "version": "~master",
     "libs-posix": ["tarsnap"],
-    "dflags": " -O "
+    "dflags": ["-O"]
 }


### PR DESCRIPTION
Nice to see that you had the time to tackle this! I've just fixed a few things in the package.json file that caught my eye:
- Package names may only contain letters, numbers, dashes and unterscores (dub should enforce that, but maybe a check is missing somewhere)
- The "version" field is obsolete and not used anymore (versions are inferred from the git branch/tag names)
- "dflags" expects an array

If you tried to register the repository, the errors should also show up in your "Manage my packages" list.
