### PR TITLE
std.c -> core.stdc

### DIFF
--- a/source/scrypt/scryptenc.d
+++ b/source/scrypt/scryptenc.d
@@ -30,7 +30,7 @@ module scrypt.scryptenc;
  * D binding created by Isak Andersson 2013 (BitPuffin@lavabit.com)
  */
 
-import std.c.stdio;
+import core.stdc.stdio;
 
 alias ubyte uint8_t;
 


### PR DESCRIPTION
std.c has been deprecated for a while now, core.stdc gives you the same thing.
